### PR TITLE
fix(source): capture tap events in add button on mobile chrome

### DIFF
--- a/src/Components/Map/Subcomponents/AddButton.tsx
+++ b/src/Components/Map/Subcomponents/AddButton.tsx
@@ -57,6 +57,10 @@ export default function AddButton({
                           onClick={() => {
                             triggerAction(layer)
                           }}
+                          onTouchEnd={(e) => {
+                            triggerAction(layer)
+                            e.preventDefault()
+                          }}
                         >
                           <img
                             src={layer.menuIcon}


### PR DESCRIPTION
fixes #105 