### PR TITLE
feat(docu): include internal types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "tailwindcss": "^3.3.1",
         "typedoc": "^0.27.6",
         "typedoc-plugin-coverage": "^3.4.1",
+        "typedoc-plugin-missing-exports": "^3.1.0",
         "typescript": "^5.7.3",
         "vite": "^6.0.11",
         "vitest": "^3.0.5"
@@ -11952,6 +11953,16 @@
       },
       "peerDependencies": {
         "typedoc": "0.25.x || 0.26.x || 0.27.x"
+      }
+    },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.1.0.tgz",
+      "integrity": "sha512-Sogbaj+qDa21NjB3SlIw4JXSwmcl/WOjwiPNaVEcPhpNG/MiRTtpwV81cT7h1cbu9StpONFPbddYWR0KV/fTWA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "0.26.x || 0.27.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:component": "cypress run --component --browser electron",
     "test:unit": "npm run test:unit:dev -- run --coverage",
     "test:unit:dev": "vitest",
-    "docs:generate": "typedoc --includeVersion --navigation.includeCategories true --plugin typedoc-plugin-coverage src/index.tsx",
+    "docs:generate": "typedoc --includeVersion --navigation.includeCategories true --plugin typedoc-plugin-missing-exports --plugin typedoc-plugin-coverage src/index.tsx",
     "update": "npx npm-check-updates"
   },
   "files": [
@@ -78,6 +78,7 @@
     "tailwindcss": "^3.3.1",
     "typedoc": "^0.27.6",
     "typedoc-plugin-coverage": "^3.4.1",
+    "typedoc-plugin-missing-exports": "^3.1.0",
     "typescript": "^5.7.3",
     "vite": "^6.0.11",
     "vitest": "^3.0.5"


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Include internal types

Include internal types, not exposed.
For this purpose the typedoc plugin [typedoc-plugin-missing-exports](https://github.com/Gerrit0/typedoc-plugin-missing-exports) is utilized,

The internal types are then displayed unter the `<internal>` category in the docs.

![image](https://github.com/user-attachments/assets/fba80264-0a5c-4a60-81ae-7df88341c5e4)

This also includes all React types and alike which can be made visible via a sidemenu.

![image](https://github.com/user-attachments/assets/7aaffa28-099d-4820-b698-7afd5a2c0d40)

Allowing to explore well documented ReactTypes
![image](https://github.com/user-attachments/assets/b7f26359-68de-48e5-8c3f-2fce994cf4be)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [ ] It looks like there is trouble with the type export in general.

### Notes

This resolves the warnings previously displayed for our internal types
![image](https://github.com/user-attachments/assets/eb584fc6-972f-4b4e-89ea-ea8cdfdee66b)

In turn it introduces some new warnings from the inner workings of React where the type resolver finds its boundaries.
![image](https://github.com/user-attachments/assets/b7c7e1d3-d477-4f5e-92e6-3a7d2fbfa430)