### PR TITLE
refactor(docu): reference the docu URL in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It is the base of [Utopia Map](https://github.com/utopia-os/utopia-map) and [Uto
 
 ## Getting Started
 
-1. If you want to use **Utopia UI** in your project, check out [`/exampes`](/examples) to see how to use its components.
+1. If you want to use **Utopia UI** in your project, check out [`/examples`](/examples) to see how to use its components.
 
 2. If you need more information you can explore [the docs](https://utopia-os.org/utopia-ui/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Utopia UI [![npm version](https://img.shields.io/npm/v/utopia-ui.svg)](https://www.npmjs.com/package/utopia-ui)  ![Build Status](https://img.shields.io/github/actions/workflow/status/utopia-os/utopia-ui/test.build.yml?branch=main) ![License](https://img.shields.io/github/license/utopia-os/utopia-ui)
+# Utopia UI [![npm version](https://img.shields.io/npm/v/utopia-ui.svg)](https://www.npmjs.com/package/utopia-ui)  ![Build Status](https://img.shields.io/github/actions/workflow/status/utopia-os/utopia-ui/test.build.yml?branch=main) [![Docs Coverage](https://utopia-os.org/utopia-ui/coverage.svg)](https://utopia-os.org/utopia-ui/) ![License](https://img.shields.io/github/license/utopia-os/utopia-ui)
 
 **UI Framework for Real-Life-Networking-Apps**
 
@@ -28,7 +28,9 @@ It is the base of [Utopia Map](https://github.com/utopia-os/utopia-map) and [Uto
 
 1. If you want to use **Utopia UI** in your project, check out [`/exampes`](/examples) to see how to use its components.
 
-2. If you like to contribute to our library, see the [Contribution Guide](/CONTRIBUTING.md) to see how to setup a development environment on your local machine.
+2. If you need more informatuin you can explore [the docs](https://utopia-os.org/utopia-ui/)
+
+3. If you like to contribute to our library, see the [Contribution Guide](/CONTRIBUTING.md) to see how to setup a development environment on your local machine.
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is the base of [Utopia Map](https://github.com/utopia-os/utopia-map) and [Uto
 
 1. If you want to use **Utopia UI** in your project, check out [`/exampes`](/examples) to see how to use its components.
 
-2. If you need more informatuin you can explore [the docs](https://utopia-os.org/utopia-ui/)
+2. If you need more information you can explore [the docs](https://utopia-os.org/utopia-ui/)
 
 3. If you like to contribute to our library, see the [Contribution Guide](/CONTRIBUTING.md) to see how to setup a development environment on your local machine.
 


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

docs: reference the URL in the `README.md`

Link to the docs [published on github](https://utopia-os.org/utopia-ui/) when pushing to `main` and include percentage badge for documentation coverage.

![image](https://github.com/user-attachments/assets/fbd20d46-024e-4bb7-9bf7-78feb2c64aa0)

![image](https://github.com/user-attachments/assets/a6957fec-8637-42c2-b691-b8a35eb07625)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None

### Notes
The coverage increases in #124 to 25%. I am not sure it will stay that way with the inclusion of internal types (#121).