### PR TITLE
refactor(other): rollup - fail when typescript has warnings or errors

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,6 +40,7 @@ export default [
       }),
       typescript({
         tsconfig: './tsconfig.json',
+        noEmitOnError: true,
       }),
       svg({ base64: true }),
     ],


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

rollup - fail when typescript has warnings or errors

Currently this is detected when building the docu. Since the developer rarely does that the problem is detected on github. This change allows the developer to discover the error early by failing the build.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- relates #148 

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
